### PR TITLE
fix body parsing & update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -548,9 +548,9 @@ dependencies = [
 
 [[package]]
 name = "psp"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34802bbcf46f255ee06e864bf4497bb264f308113b000facd08a32dd154936e0"
+checksum = "b5da5105eb984565819ac0f3e09132991b9169b1b57f7172573eb710507a276b"
 dependencies = [
  "bitflags",
  "libm",
@@ -562,9 +562,9 @@ dependencies = [
 
 [[package]]
 name = "psp-net"
-version = "0.1.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ba45e6613fe03120fbfe53679c287db9ecefebaee9e6a4bd7baf1763b1f5166"
+checksum = "fe9537bd90d5d7db116983e439b71651b4e3999f46438889ae05c40c93b2b201"
 dependencies = [
  "dns-protocol",
  "embedded-io",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -548,9 +548,9 @@ dependencies = [
 
 [[package]]
 name = "psp"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2203da58ae0405ae84237505ae05e9b3b28eb0c0e5d9afa8a5e1e80c70db5eb4"
+checksum = "34802bbcf46f255ee06e864bf4497bb264f308113b000facd08a32dd154936e0"
 dependencies = [
  "bitflags",
  "libm",
@@ -562,9 +562,9 @@ dependencies = [
 
 [[package]]
 name = "psp-net"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b51b78b7d80f0d721f45f21cacd6ff733b3e0afb37ebc75e644a31fddc8ece12"
+checksum = "1ba45e6613fe03120fbfe53679c287db9ecefebaee9e6a4bd7baf1763b1f5166"
 dependencies = [
  "dns-protocol",
  "embedded-io",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-psp = { version = "0.3.7" }
-psp-net = { version = "0.1.1", default-features = false }
+psp = { version = "0.3.8" }
+psp-net = { version = "0.1.2", default-features = false }
 heapless = { version = "0.8", features = ["serde"] }
 regex = { version = "1.10", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-psp = { version = "0.3.8" }
-psp-net = { version = "0.1.2", default-features = false }
+psp = { version = "0.3.9" }
+psp-net = { version = "0.2.0", default-features = false }
 heapless = { version = "0.8", features = ["serde"] }
 regex = { version = "1.10", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive"] }

--- a/src/openai/types.rs
+++ b/src/openai/types.rs
@@ -107,6 +107,7 @@ impl Display for ChatHistory {
 }
 
 #[derive(Debug, Deserialize)]
+#[allow(unused)]
 pub struct Usage {
     pub prompt_tokens: i32,
     pub completion_tokens: i32,
@@ -114,12 +115,14 @@ pub struct Usage {
 }
 
 #[derive(Debug, Deserialize)]
+#[allow(unused)]
 pub struct ResponseMessage {
     pub role: heapless::String<32>,
     pub content: heapless::String<1024>,
 }
 
 #[derive(Debug, Deserialize)]
+#[allow(unused)]
 /// # Note
 /// This struct does not support the [`Self::logprobs`] field different from `None` yet.
 pub struct CompletionChoice {
@@ -134,6 +137,7 @@ pub struct CompletionChoice {
 pub struct LogprobResult {}
 
 #[derive(Debug, Deserialize)]
+#[allow(unused)]
 /// Completion response from OpenAI.
 pub struct CompletionResponse<'a> {
     pub id: &'a str,

--- a/src/osk/osk_state.rs
+++ b/src/osk/osk_state.rs
@@ -1,8 +1,8 @@
-use psp::sys::{sceUtilityOskGetStatus, SceUtilityOskState};
+use psp::sys::{sceUtilityOskGetStatus, PspUtilityDialogState};
 
 /// The state of the osk.
 pub struct OskState {
-    state: SceUtilityOskState,
+    state: PspUtilityDialogState,
 }
 
 impl OskState {
@@ -11,14 +11,20 @@ impl OskState {
     /// Create a new OskState.
     pub fn new() -> Self {
         Self {
-            state: unsafe { core::mem::transmute(sceUtilityOskGetStatus()) },
+            state: unsafe {
+                core::mem::transmute::<i32, psp::sys::PspUtilityDialogState>(
+                    sceUtilityOskGetStatus(),
+                )
+            },
         }
     }
 
     #[inline]
     /// Get the current state of the osk.
-    pub fn get(&mut self) -> SceUtilityOskState {
-        self.state = unsafe { core::mem::transmute(sceUtilityOskGetStatus()) };
+    pub fn get(&mut self) -> PspUtilityDialogState {
+        self.state = unsafe {
+            core::mem::transmute::<i32, psp::sys::PspUtilityDialogState>(sceUtilityOskGetStatus())
+        };
         self.state
     }
 }
@@ -27,7 +33,7 @@ impl From<i32> for OskState {
     #[inline]
     fn from(state: i32) -> Self {
         Self {
-            state: unsafe { core::mem::transmute(state) },
+            state: unsafe { core::mem::transmute::<i32, psp::sys::PspUtilityDialogState>(state) },
         }
     }
 }

--- a/src/osk/prelude.rs
+++ b/src/osk/prelude.rs
@@ -65,7 +65,7 @@ pub fn default_osk_params(data: &mut SceUtilityOskData) -> SceUtilityOskParams {
         },
         datacount: 1,
         data,
-        state: sys::SceUtilityOskState::None,
+        state: sys::PspUtilityDialogState::None,
         unk_60: 0,
     }
 }


### PR DESCRIPTION
Update dependencies and fix body parsing.

> Lately the previous way of parsing body has stopped working, as some characters (1e3 at the beginning, and 0 at the end) started to get printed around the json body. This commit takes this into account, to solve the issue.